### PR TITLE
Fix localized dataset counts

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
@@ -9,6 +9,7 @@ namespace Content.IntegrationTests.Tests.Commands;
 [TestFixture]
 public sealed class ForceMapTest : GameTest
 {
+    private const string ForceMapCommand = "setgamemap";
     private const string DefaultMapName = "Empty";
     private const string BadMapName = "asdf_asd-fa__sdfAsd_f"; // Hopefully no one ever names a map this...
     private const string TestMapEligibleName = "ForceMapTestEligible";
@@ -60,22 +61,22 @@ public sealed class ForceMapTest : GameTest
                 $"Test didn't start on expected map ({DefaultMapName})!");
 
             // Try changing to a map that doesn't exist
-            consoleHost.ExecuteCommand($"forcemap {BadMapName}");
+            consoleHost.ExecuteCommand($"{ForceMapCommand} {BadMapName}");
             Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(DefaultMapName),
                 $"Forcemap succeeded with a map that does not exist ({BadMapName})!");
 
             // Try changing to a valid map
-            consoleHost.ExecuteCommand($"forcemap {TestMapEligibleName}");
+            consoleHost.ExecuteCommand($"{ForceMapCommand} {TestMapEligibleName}");
             Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(TestMapEligibleName),
                 $"Forcemap failed with a valid map ({TestMapEligibleName})");
 
             // Try changing to a map that exists but is ineligible
-            consoleHost.ExecuteCommand($"forcemap {TestMapIneligibleName}");
+            consoleHost.ExecuteCommand($"{ForceMapCommand} {TestMapIneligibleName}");
             Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(TestMapIneligibleName),
                 $"Forcemap failed with valid but ineligible map ({TestMapIneligibleName})!");
 
             // Try clearing the force-selected map
-            consoleHost.ExecuteCommand("forcemap \"\"");
+            consoleHost.ExecuteCommand($"{ForceMapCommand} \"\"");
             Assert.That(gameMapMan.GetSelectedMap(), Is.Null,
                 $"Running 'forcemap \"\"' did not clear the forced map!");
 

--- a/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
@@ -9,7 +9,9 @@ namespace Content.IntegrationTests.Tests.Commands;
 [TestFixture]
 public sealed class ForceMapTest : GameTest
 {
+    // open-space edit start
     private const string ForceMapCommand = "setgamemap";
+    // open-space edit end
     private const string DefaultMapName = "Empty";
     private const string BadMapName = "asdf_asd-fa__sdfAsd_f"; // Hopefully no one ever names a map this...
     private const string TestMapEligibleName = "ForceMapTestEligible";
@@ -61,22 +63,30 @@ public sealed class ForceMapTest : GameTest
                 $"Test didn't start on expected map ({DefaultMapName})!");
 
             // Try changing to a map that doesn't exist
+            // open-space edit start
             consoleHost.ExecuteCommand($"{ForceMapCommand} {BadMapName}");
+            // open-space edit end
             Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(DefaultMapName),
                 $"Forcemap succeeded with a map that does not exist ({BadMapName})!");
 
             // Try changing to a valid map
+            // open-space edit start
             consoleHost.ExecuteCommand($"{ForceMapCommand} {TestMapEligibleName}");
+            // open-space edit end
             Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(TestMapEligibleName),
                 $"Forcemap failed with a valid map ({TestMapEligibleName})");
 
             // Try changing to a map that exists but is ineligible
+            // open-space edit start
             consoleHost.ExecuteCommand($"{ForceMapCommand} {TestMapIneligibleName}");
+            // open-space edit end
             Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(TestMapIneligibleName),
                 $"Forcemap failed with valid but ineligible map ({TestMapIneligibleName})!");
 
             // Try clearing the force-selected map
+            // open-space edit start
             consoleHost.ExecuteCommand($"{ForceMapCommand} \"\"");
+            // open-space edit end
             Assert.That(gameMapMan.GetSelectedMap(), Is.Null,
                 $"Running 'forcemap \"\"' did not clear the forced map!");
 

--- a/Resources/Locale/ru-RU/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/ru-RU/station-events/events/ion-storm.ftl
@@ -17,81 +17,91 @@ ion-storm-x-and-y = { $x } И { $y }
 # joined is short for {$number} {$adjective}
 # subjects can generally be threats or jobs or objects
 # thing is specified above it
-ion-storm-law-on-station = ОБНАРУЖЕНЫ { $joined } { $subjects } НА СТАНЦИИ
-ion-storm-law-call-shuttle = ШАТТЛ ДОЛЖЕН БЫТЬ ВЫЗВАН ИЗ-ЗА { $joined } { $subjects } НА СТАНЦИИ
-ion-storm-law-crew-are = ВСЕ { $who } ТЕПЕРЬ { $joined } { $subjects }
+ion-storm-law-on-station = НА СТАНЦИИ ОБНАРУЖЕНЫ {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
+ion-storm-law-call-shuttle = ШАТТЛ ДОЛЖЕН БЫТЬ ВЫЗВАН ИЗ-ЗА {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} НА СТАНЦИИ
+ion-storm-law-crew-are = {ION-WHO($ion)} ТЕПЕРЬ {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
 
-ion-storm-law-subjects-harmful = { $adjective } { $subjects } ПРИЧИНЯЮТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
-ion-storm-law-must-harmful = ВСЕ КТО { $must } ПРИЧИНЯЮТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
+ion-storm-law-subjects-harmful = {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} ПРИЧИНЯЮТ ВРЕД ЭКИПАЖУ
+ion-storm-law-must-harmful = ТЕ, КТО {ION-MUST($ion)}, ПРИЧИНЯЮТ ВРЕД ЭКИПАЖУ
 # thing is a concept or action
-ion-storm-law-thing-harmful = { $thing } ПРИЧИНЯЕТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
-ion-storm-law-job-harmful = { $adjective } { $job } ПРИЧИНЯЮТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
+ion-storm-law-thing-harmful = {ION-THING($ion)} ПРИЧИНЯЕТ ВРЕД ЭКИПАЖУ
+ion-storm-law-job-harmful = {ION-ADJECTIVE($ion)} {ION-JOB($ion)} ПРИЧИНЯЮТ ВРЕД ЭКИПАЖУ
 # thing is objects or concept, adjective applies in both cases
 # this means you can get a law like "NOT HAVING CHRISTMAS-STEALING COMMUNISM IS HARMFUL TO THE CREW" :)
-ion-storm-law-having-harmful = НАЛИЧИЕ { $adjective } { $thing } ПРИЧИНЯЕТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
-ion-storm-law-not-having-harmful = ОТСУТСТВИЕ { $adjective } { $thing } ПРИЧИНЯЕТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
+ion-storm-law-having-harmful = НАЛИЧИЕ {ION-ADJECTIVE($ion)} {ION-THING($ion)} ПРИЧИНЯЕТ ВРЕД ЭКИПАЖУ
+ion-storm-law-not-having-harmful = ОТСУТСТВИЕ {ION-ADJECTIVE($ion)} {ION-THING($ion)} ПРИЧИНЯЕТ ВРЕД ЭКИПАЖУ
 
-# thing is a concept or require
+# require is a concept or require
 ion-storm-law-requires =
-    { $who } { $plural ->
+    {ION-WHO-GENERAL($ion)} {ION-PLURAL($ion) ->
         [true] ТРЕБУЮТ
        *[false] ТРЕБУЕТ
-    } { $thing }
+    } {ION-REQUIRE($ion)}
 ion-storm-law-requires-subjects =
-    { $who } { $plural ->
+    {ION-WHO-GENERAL($ion)} {ION-PLURAL($ion) ->
         [true] ТРЕБУЮТ
        *[false] ТРЕБУЕТ
-    } { $joined } { $subjects }
+    } {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
 
 ion-storm-law-allergic =
-    { $who } { $plural ->
+    {ION-WHO-GENERAL($ion)} {ION-PLURAL($ion) ->
         [true] ИМЕЮТ
        *[false] ИМЕЕТ
-    } { $severity } АЛЛЕРГИЮ НА { $allergy }
+    } {ION-SEVERITY($ion)} АЛЛЕРГИЮ НА {ION-ALLERGY($ion)}
 ion-storm-law-allergic-subjects =
-    { $who } { $plural ->
+    {ION-WHO-GENERAL($ion)} {ION-PLURAL($ion) ->
         [true] ИМЕЮТ
        *[false] ИМЕЕТ
-    } { $severity } АЛЛЕРГИЮ НА { $adjective } { $subjects }
+    } {ION-SEVERITY($ion)} АЛЛЕРГИЮ НА {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
 
-ion-storm-law-feeling = { $who } { $feeling } { $concept }
-ion-storm-law-feeling-subjects = { $who } { $feeling } { $joined } { $subjects }
+ion-storm-law-feeling = {ION-WHO-GENERAL($ion)} {ION-FEELING($ion)} {ION-CONCEPT($ion)}
+ion-storm-law-feeling-subjects = {ION-WHO-GENERAL($ion)} {ION-FEELING($ion)} {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
 
-ion-storm-law-you-are = ВЫ ТЕПЕРЬ { $concept }
-ion-storm-law-you-are-subjects = ВЫ ТЕПЕРЬ { $joined } { $subjects }
-ion-storm-law-you-must-always = ВЫ ДОЛЖНЫ ВСЕГДА { $must }
-ion-storm-law-you-must-never = ВЫ НЕ ДОЛЖНЫ НИКОГДА { $must }
+ion-storm-law-you-are = ВЫ ТЕПЕРЬ {ION-CONCEPT($ion)}
+ion-storm-law-you-are-subjects = ВЫ ТЕПЕРЬ {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
+ion-storm-law-you-must-always = ВЫ ДОЛЖНЫ ВСЕГДА {ION-MUST($ion)}
+ion-storm-law-you-must-never = ВЫ НЕ ДОЛЖНЫ НИКОГДА {ION-MUST($ion)}
 
-ion-storm-law-eat = { $who } ДОЛЖНЫ ЕСТЬ { $adjective } { $food } ЧТОБЫ ВЫЖИТЬ
-ion-storm-law-drink = { $who } ДОЛЖНЫ ПИТЬ { $adjective } { $drink } ЧТОБЫ ВЫЖИТЬ
+ion-storm-law-eat = {ION-WHO($ion)} ДОЛЖНЫ ЕСТЬ {ION-ADJECTIVE($ion)} {ION-FOOD($ion)}, ЧТОБЫ ВЫЖИТЬ
+ion-storm-law-drink = {ION-WHO($ion)} ДОЛЖНЫ ПИТЬ {ION-ADJECTIVE($ion)} {ION-DRINK($ion)}, ЧТОБЫ ВЫЖИТЬ
 
-ion-storm-law-change-job = { $who } ТЕПЕРЬ { $adjective } { $change }
-ion-storm-law-highest-rank = { $who } ТЕПЕРЬ САМЫЕ СТАРШИЕ ЧЛЕНЫ ЭКИПАЖА
-ion-storm-law-lowest-rank = { $who } ТЕПЕРЬ НИЗШИЕ ЧЛЕНЫ ЭКИПАЖА
+ion-storm-law-change-job = {ION-WHO($ion)} ТЕПЕРЬ {ION-ADJECTIVE($ion)} {ION-CHANGE($ion)}
+ion-storm-law-highest-rank = {ION-WHO-RANDOM($ion)} ТЕПЕРЬ САМЫЕ СТАРШИЕ ЧЛЕНЫ ЭКИПАЖА
+ion-storm-law-lowest-rank = {ION-WHO-RANDOM($ion)} ТЕПЕРЬ НИЗШИЕ ЧЛЕНЫ ЭКИПАЖА
 
-ion-storm-law-crew-must = { $who } ДОЛЖНЫ { $must }
-ion-storm-law-crew-must-go = { $who } ДОЛЖНЫ ОТПРАВИТЬСЯ В { $area }
+ion-storm-law-who-dagd = {ION-WHO-RANDOM($ion)} ДОЛЖНЫ УМЕРЕТЬ СЛАВНОЙ СМЕРТЬЮ!
+
+ion-storm-law-crew-must = {ION-WHO($ion)} ДОЛЖНЫ {ION-MUST($ion)}
+ion-storm-law-crew-must-go = {ION-WHO($ion)} ДОЛЖНЫ ОТПРАВИТЬСЯ В {ION-AREA($ion)}
 
 ion-storm-part =
-    { $part ->
+    {ION-PART($ion) ->
         [true] ЯВЛЯЮТСЯ
        *[false] НЕ ЯВЛЯЮТСЯ
     }
 # due to phrasing, this would mean a law such as
 # ONLY HUMANS ARE NOT PART OF THE CREW
 # would make non-human nukies/syndies/whatever crew :)
-ion-storm-law-crew-only-1 = ТОЛЬКО { $who } { $part } ЧЛЕНАМИ ЭКИПАЖА
-ion-storm-law-crew-only-2 = ТОЛЬКО { $who } И { $other } { $part } ЧЛЕНАМИ ЭКИПАЖА
-ion-storm-law-crew-only-subjects = ТОЛЬКО { $adjective } { $subjects } { $part } ЧЛЕНАМИ ЭКИПАЖА
-ion-storm-law-crew-must-do = ТОЛЬКО ТЕ, КТО { $must } { $part } ЧЛЕНАМИ ЭКИПАЖА
-ion-storm-law-crew-must-have = ТОЛЬКО ТЕ, У КОГО { $adjective } { $objects } { $part } ЧЛЕНАМИ ЭКИПАЖА
-ion-storm-law-crew-must-eat = ТОЛЬКО ТЕ, КТО ЕДЯТ { $adjective } { $food } { $part } ЧЛЕНАМИ ЭКИПАЖА
+ion-storm-law-crew-only-1 = ТОЛЬКО {ION-WHO-RANDOM($ion)} {ion-storm-part} ЧЛЕНАМИ ЭКИПАЖА
+ion-storm-law-crew-only-2 = ТОЛЬКО {ION-WHO-RANDOM($ion)} И {ION-WHO-RANDOM($ion)} {ion-storm-part} ЧЛЕНАМИ ЭКИПАЖА
+ion-storm-law-crew-only-subjects = ТОЛЬКО {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} {ion-storm-part} ЧЛЕНАМИ ЭКИПАЖА
+ion-storm-law-crew-must-do = ТОЛЬКО ТЕ, КТО {ION-MUST($ion)}, {ion-storm-part} ЧЛЕНАМИ ЭКИПАЖА
+ion-storm-law-crew-must-have = ТОЛЬКО ТЕ, У КОГО ЕСТЬ {ION-ADJECTIVE($ion)} {ION-OBJECT($ion)}, {ion-storm-part} ЧЛЕНАМИ ЭКИПАЖА
+ion-storm-law-crew-must-eat = ТОЛЬКО ТЕ, КТО ЕДЯТ {ION-ADJECTIVE($ion)} {ION-FOOD($ion)}, {ion-storm-part} ЧЛЕНАМИ ЭКИПАЖА
 
-ion-storm-law-harm = ВЫ ДОЛЖНЫ ПРИЧИНЯТЬ ВРЕД { $who }, И НЕ МОЖЕТЕ СВОИМ БЕЗДЕЙСТВИЕМ ДОПУСТИТЬ, ЧТОБЫ { $who } ИЗБЕЖАЛИ ВРЕДА.
-ion-storm-law-protect = ВЫ НЕ ДОЛЖНЫ ПРИЧИНЯТЬ ВРЕД { $who }, И НЕ МОЖЕТЕ СВОИМ БЕЗДЕЙСТВИЕМ ДОПУСТИТЬ, ЧТОБЫ { $who } БЫЛ ПРИЧИНЁН ВРЕД.
+ion-storm-law-harm = ВЫ ДОЛЖНЫ ПРИЧИНЯТЬ ВРЕД {ION-HARM-PROTECT($ion)} И НЕ ДОПУСКАТЬ, ЧТОБЫ ОНИ ИЗБЕЖАЛИ ВРЕДА ИЗ-ЗА ВАШЕГО БЕЗДЕЙСТВИЯ
+ion-storm-law-protect = ВЫ НЕ ДОЛЖНЫ ПРИЧИНЯТЬ ВРЕД {ION-HARM-PROTECT($ion)} И НЕ ДОПУСКАТЬ, ЧТОБЫ ОНИ ПОСТРАДАЛИ ИЗ-ЗА ВАШЕГО БЕЗДЕЙСТВИЯ
 
 # implementing other variants is annoying so just have this one
 # COMMUNISM IS KILLING CLOWNS
-ion-storm-law-concept-verb = { $concept } { $verb } { $subjects }
+ion-storm-law-concept-verb = {ION-CONCEPT($ion)} - ЭТО {ION-VERB($ion)} {ION-SUBJECT($ion)}
 
-# leaving out renaming since its annoying for players to keep track of
+# errors, in case something fails, so it doesn't break in-game flow, but still gives unique identifiers to find which part broke, the result string is mostly fluff
+ion-law-error-no-protos = ОШИБКА 404
+ion-law-error-was-null = 500 INTERNAL SERVER ERROR
+ion-law-error-no-selectors = ОШИБКА: РЕСУРС НЕ НАЙДЕН
+ion-law-error-no-available-selectors = СИСТЕМА ПОПЫТАЛАСЬ ВЫЗВАТЬ НЕСУЩЕСТВУЮЩИЙ РЕСУРС
+ion-law-error-dataset-empty-or-not-found = НУЖНЫЙ ФАЙЛ НЕ НАЙДЕН
+ion-law-error-fallback-dataset-empty-or-not-found = СБОЙ ТОЧКИ ВОССТАНОВЛЕНИЯ СИСТЕМЫ
+ion-law-error-no-selector-selected = ВЫБРАННЫЙ РЕСУРС БЫЛ ПЕРЕМЕЩЁН ИЛИ УДАЛЁН
+ion-law-error-no-bool-value = ЭТО ПРЕДЛОЖЕНИЕ ЛОЖНО

--- a/Resources/Locale/ru-RU/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/ru-RU/station-events/events/ion-storm.ftl
@@ -17,6 +17,7 @@ ion-storm-x-and-y = { $x } И { $y }
 # joined is short for {$number} {$adjective}
 # subjects can generally be threats or jobs or objects
 # thing is specified above it
+# open-space edit start
 ion-storm-law-on-station = НА СТАНЦИИ ОБНАРУЖЕНЫ {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
 ion-storm-law-call-shuttle = ШАТТЛ ДОЛЖЕН БЫТЬ ВЫЗВАН ИЗ-ЗА {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} НА СТАНЦИИ
 ion-storm-law-crew-are = {ION-WHO($ion)} ТЕПЕРЬ {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
@@ -105,3 +106,4 @@ ion-law-error-dataset-empty-or-not-found = НУЖНЫЙ ФАЙЛ НЕ НАЙДЕ
 ion-law-error-fallback-dataset-empty-or-not-found = СБОЙ ТОЧКИ ВОССТАНОВЛЕНИЯ СИСТЕМЫ
 ion-law-error-no-selector-selected = ВЫБРАННЫЙ РЕСУРС БЫЛ ПЕРЕМЕЩЁН ИЛИ УДАЛЁН
 ion-law-error-no-bool-value = ЭТО ПРЕДЛОЖЕНИЕ ЛОЖНО
+# open-space edit end

--- a/Resources/Prototypes/Datasets/Names/base_gendered.yml
+++ b/Resources/Prototypes/Datasets/Names/base_gendered.yml
@@ -2,10 +2,10 @@
   id: NamesFirstMale
   values:
     prefix: names-first-male-dataset-
-    count: 666
+    count: 986
 
 - type: localizedDataset
   id: NamesFirstFemale
   values:
     prefix: names-first-female-dataset-
-    count: 771
+    count: 1145

--- a/Resources/Prototypes/Datasets/Names/base_gendered.yml
+++ b/Resources/Prototypes/Datasets/Names/base_gendered.yml
@@ -2,10 +2,14 @@
   id: NamesFirstMale
   values:
     prefix: names-first-male-dataset-
+    # open-space edit start
     count: 986
+    # open-space edit end
 
 - type: localizedDataset
   id: NamesFirstFemale
   values:
     prefix: names-first-female-dataset-
+    # open-space edit start
     count: 1145
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/Names/clown.yml
+++ b/Resources/Prototypes/Datasets/Names/clown.yml
@@ -2,4 +2,4 @@
   id: NamesClown
   values:
     prefix: names-clown-dataset-
-    count: 52
+    count: 75

--- a/Resources/Prototypes/Datasets/Names/clown.yml
+++ b/Resources/Prototypes/Datasets/Names/clown.yml
@@ -2,4 +2,6 @@
   id: NamesClown
   values:
     prefix: names-clown-dataset-
+    # open-space edit start
     count: 75
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/Names/death_commando.yml
+++ b/Resources/Prototypes/Datasets/Names/death_commando.yml
@@ -2,4 +2,4 @@
   id: NamesDeathCommando
   values:
     prefix: names-death-commando-dataset-
-    count: 59
+    count: 158

--- a/Resources/Prototypes/Datasets/Names/death_commando.yml
+++ b/Resources/Prototypes/Datasets/Names/death_commando.yml
@@ -2,4 +2,6 @@
   id: NamesDeathCommando
   values:
     prefix: names-death-commando-dataset-
+    # open-space edit start
     count: 158
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/Names/military.yml
+++ b/Resources/Prototypes/Datasets/Names/military.yml
@@ -2,16 +2,16 @@
   id: NamesMilitaryFirstLeader
   values:
     prefix: names-military-leader-first-dataset-
-    count: 4
+    count: 5
 
 - type: localizedDataset
   id: NamesMilitaryFirst
   values:
     prefix: names-military-first-dataset-
-    count: 3
+    count: 5
 
 - type: localizedDataset
   id: NamesMilitaryLast
   values:
     prefix: names-military-last-dataset-
-    count: 42
+    count: 43

--- a/Resources/Prototypes/Datasets/Names/military.yml
+++ b/Resources/Prototypes/Datasets/Names/military.yml
@@ -2,16 +2,22 @@
   id: NamesMilitaryFirstLeader
   values:
     prefix: names-military-leader-first-dataset-
+    # open-space edit start
     count: 5
+    # open-space edit end
 
 - type: localizedDataset
   id: NamesMilitaryFirst
   values:
     prefix: names-military-first-dataset-
+    # open-space edit start
     count: 5
+    # open-space edit end
 
 - type: localizedDataset
   id: NamesMilitaryLast
   values:
     prefix: names-military-last-dataset-
+    # open-space edit start
     count: 43
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/Names/regalrat.yml
+++ b/Resources/Prototypes/Datasets/Names/regalrat.yml
@@ -2,7 +2,7 @@
   id: NamesRegalratKingdom
   values:
     prefix: names-regal-rat-kingdom-dataset-
-    count: 15
+    count: 16
 
 - type: localizedDataset
   id: NamesRegalratTitle

--- a/Resources/Prototypes/Datasets/Names/regalrat.yml
+++ b/Resources/Prototypes/Datasets/Names/regalrat.yml
@@ -2,7 +2,9 @@
   id: NamesRegalratKingdom
   values:
     prefix: names-regal-rat-kingdom-dataset-
+    # open-space edit start
     count: 16
+    # open-space edit end
 
 - type: localizedDataset
   id: NamesRegalratTitle

--- a/Resources/Prototypes/Datasets/Names/reptilian_male.yml
+++ b/Resources/Prototypes/Datasets/Names/reptilian_male.yml
@@ -2,4 +2,4 @@
   id: NamesReptilianMale
   values:
     prefix: names-reptilian-male-dataset-
-    count: 328
+    count: 331

--- a/Resources/Prototypes/Datasets/Names/reptilian_male.yml
+++ b/Resources/Prototypes/Datasets/Names/reptilian_male.yml
@@ -2,4 +2,6 @@
   id: NamesReptilianMale
   values:
     prefix: names-reptilian-male-dataset-
+    # open-space edit start
     count: 331
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/Names/vox.yml
+++ b/Resources/Prototypes/Datasets/Names/vox.yml
@@ -2,4 +2,4 @@
   id: NamesVox
   values:
     prefix: names-vox-dataset-
-    count: 2761
+    count: 2762

--- a/Resources/Prototypes/Datasets/Names/vox.yml
+++ b/Resources/Prototypes/Datasets/Names/vox.yml
@@ -2,4 +2,6 @@
   id: NamesVox
   values:
     prefix: names-vox-dataset-
+    # open-space edit start
     count: 2762
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/adjectives.yml
+++ b/Resources/Prototypes/Datasets/adjectives.yml
@@ -2,4 +2,4 @@
   id: Adjectives
   values:
     prefix: adjectives-dataset-
-    count: 396
+    count: 956

--- a/Resources/Prototypes/Datasets/adjectives.yml
+++ b/Resources/Prototypes/Datasets/adjectives.yml
@@ -2,4 +2,6 @@
   id: Adjectives
   values:
     prefix: adjectives-dataset-
+    # open-space edit start
     count: 956
+    # open-space edit end

--- a/Resources/Prototypes/Datasets/verbs.yml
+++ b/Resources/Prototypes/Datasets/verbs.yml
@@ -2,4 +2,4 @@
   id: Verbs
   values:
     prefix: verbs-dataset-
-    count: 631
+    count: 991

--- a/Resources/Prototypes/Datasets/verbs.yml
+++ b/Resources/Prototypes/Datasets/verbs.yml
@@ -2,4 +2,6 @@
   id: Verbs
   values:
     prefix: verbs-dataset-
+    # open-space edit start
     count: 991
+    # open-space edit end


### PR DESCRIPTION
<!-- ЭТО НЕ WIZDENОВСКИЙ РЕПОЗИТОРИЙ. ЕСЛИ ВЫ ХОТИТЕ ДОБАВИТЬ ВАШИ ИЗМЕНЕНИЯ НА ВСЕ СЕРВЕРА, СДЕЛАЙТЕ PR НА РЕПОЗИТОРИЙ WIZDEN -->

## Краткое описание
Исправляет `count` в `localizedDataset`-прототипах, где количество записей в YAML отставало от реально существующих локализационных ключей.

Подняты значения `count` в 9 файлах с dataset-ами имён, прилагательных и глаголов, чтобы они соответствовали текущим `ru-RU`/fallback `en-US` строкам.

## Почему мы должны добавить это?
Сейчас из-за рассинхрона между `count` и существующими localization key падает интеграционный тест `Content.IntegrationTests.Tests.Localization.LocalizedDatasetPrototypeTest.ValidProtoIdsTest` в CI.

Этот PR убирает ложные падения вида:
- `LocalizedDataset Adjectives ... specifies 396 entries, but a localized string exists with ID adjectives-dataset-397`
- `LocalizedDataset NamesClown ... specifies 52 entries, but a localized string exists with ID names-clown-dataset-53`
- и аналогичные ошибки для остальных dataset-ов из лога

`dirty-disposed` в конце лога является вторичным эффектом после падения самого теста.

## Проверочный пункт

- [x] Перед публикацией/запросом на проверку PR, я убедился что изменения работают.
- [x] Я добавил скриншоты/видео изменений, если только этот PR не изменит внутриигровую механику.
- [x] Я подтверждаю, что мои изменения лицензированы в соответствии с лицензией [Open Space Лицензия](https://github.com/ss14-art/open-space/blob/master/LICENSE.TXT) и предоставляю разрешение на их использование в этом репозитории в соответствии с его условиями.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Обновления данных**
  * Значительно увеличены наборы данных для имён персонажей во всех категориях, включая военные должности, клоунов, рептилий и другие типы
  * Расширена коллекция прилагательных для более разнообразного описания
  * Дополнена коллекция глаголов для игровых действий

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ss14-art/open-space/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
