### PR TITLE
ai tools (part 2)

### DIFF
--- a/.agents/rules/ss14-skill-preflight-and-refresh.md
+++ b/.agents/rules/ss14-skill-preflight-and-refresh.md
@@ -35,13 +35,22 @@ Load these skills:
 - Player-facing text in C# or localized component fields: `ss14-localization-code`
 - Network events, `NetEntity`, replicated messages, or shared/server/client network flow: `ss14-netcode`
 - `Appearance`, `GenericVisualizer`, or sprite-layer state work: `ss14-graphics-generic-visualizer-appearance`
+- Sprites, RSI metadata, overlays, shaders, or custom visual effects: `ss14-sprite-overlays-shaders`
 - Writing or selecting tests: `ss14-tests-authoring`
 - Architecture explanation, onboarding, or first-feature guidance: `ss14-prototype-basics`, `ss14-ecs-basics`, `ss14-client-server-shared`
 - Debugging, VV, logs, breakpoints, or runtime investigation: `ss14-debugging-workflow`, `ss14-common-api-patterns`
 - Common gameplay helper APIs such as entity-system methods, spawning, audio, popups, or random: `ss14-common-api-patterns`
+- Audio routing, sound assets, sound collections, ambient/music, or predicted sound feedback: `ss14-audio`
+- Atmospherics, gases, fire, pressure, pipes, atmos devices, or atmos UI: `ss14-atmos`
+- Transforms, coordinates, grids, maps, anchoring, movement, collision, fixtures, or physics: `ss14-transform-physics`
+- PVS, visibility, network interest, PVS filters, PVS overrides, or PVS-sensitive client code: `ss14-pvs`
 - Porting, license checks, or attribution: `ss14-porting-and-licensing`
 - AI workflow and prompt/verification guidance for this repo: `ss14-ai-workflow`
-- XAML, BUI, or client UI: `ss14-ui-bui`
+- XAML windows, controls, code-behind, or client UI layout: `ss14-ui-xaml`
+- BUI flows, UI keys, BUI state/messages, or `BoundUserInterface` classes: `ss14-ui-bui`
+- EUI flows, `BaseEui`, `EuiStateBase`, `EuiMessageBase`, or admin/debug UI sessions: `ss14-ui-eui`
+- Database models, EF Core contexts, migrations, persistence services, or schema compatibility: `ss14-databases-migrations`
+- NPCs, HTN, pathfinding, steering, mob AI, AI debug overlays, or NPC prototypes: `ss14-npc-ai`
 - Broad gameplay/resource routing: `ss14-gameplay-feature`, `ss14-prototypes-locale`
 
 ## Working Notes

--- a/.agents/skills/ss14-atmos/SKILL.md
+++ b/.agents/skills/ss14-atmos/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ss14-atmos
+description: Work with SS14 atmospherics, gases, gas mixtures, fire, pressure, pipes, vents, pumps, scrubbers, air alarms, atmos overlays, and atmos-related prototypes or UI.
+---
+
+# SS14 Atmos
+
+Use this skill when a change touches gas simulation, atmos devices, fire, pressure, or atmos UI.
+
+Atmos is simulation-heavy and easy to desync or slow down. Keep server authority clear, reuse existing atmos device patterns, and avoid broad per-tile work unless the surrounding system already does it that way.
+
+## Workflow
+
+1. Locate the simulation owner.
+- Server systems own gas, fire, pressure, pipe networks, and authoritative device behavior.
+- Client systems should render overlays, pipe visuals, and UI from replicated or explicitly sent state.
+- Shared code should stay limited to shared components, enums, UI messages, and data contracts.
+
+2. Follow existing atmos units and data shapes.
+- Treat temperature, pressure, moles, and gas ratios consistently with nearby code.
+- Use existing `Gas`, `GasMixture`, pipe, device, and alarm patterns instead of inventing parallel data containers.
+- Keep device settings prototype-driven or component-driven when content needs to tune them.
+
+3. Be careful with hot paths.
+- Atmos updates can touch many tiles or devices; avoid allocations, LINQ, broad entity queries, and repeated prototype lookups in update loops.
+- Load `ss14-standard-optimizations` for per-tile, per-grid, or frequent-event changes.
+
+4. Keep visuals and UI separate from simulation.
+- Use appearance, overlays, BUI state, and localized UI text for presentation.
+- Do not make UI actions mutate client state directly; route through existing BUI/server authority paths.
+
+5. Validate the resource layer.
+- Update prototypes, FTL, and UI labels together.
+- Run YAML validation for prototype changes and build affected C# projects for code changes.
+
+## Reference Map
+
+- `../ss14-standard-optimizations/SKILL.md`
+- `../ss14-ui-bui/SKILL.md`
+- `../ss14-ui-xaml/SKILL.md`
+- `../ss14-sprite-overlays-shaders/SKILL.md`
+- `../ss14-prediction/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Shared/Atmos/**`
+- `Content.Server/Atmos/**`
+- `Content.Client/Atmos/**`
+- `Resources/Prototypes/**/Atmos/**`
+- `Resources/Locale/**/atmos*`
+
+## Common Pitfalls
+
+- Moving server-authoritative simulation into client visuals or UI handlers.
+- Adding expensive work inside atmos update loops.
+- Forgetting localization for atmos UI, alarms, or device feedback.
+- Changing pipe/device behavior without checking matching shared messages and client UI.

--- a/.agents/skills/ss14-atmos/agents/openai.yaml
+++ b/.agents/skills/ss14-atmos/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 Atmos"
+  short_description: "Atmospherics, gases, fire, pipes, and atmos UI"
+  default_prompt: "Use $ss14-atmos for SS14 atmospherics, gas, fire, pipe, and atmos device work."

--- a/.agents/skills/ss14-audio/SKILL.md
+++ b/.agents/skills/ss14-audio/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ss14-audio
+description: Work with SS14 audio systems, sound specifiers, sound collections, ambient or lobby music, jukeboxes, predicted sound feedback, or audio assets under `Resources/Audio` and `Resources/Prototypes/SoundCollections`.
+---
+
+# SS14 Audio
+
+Use this skill when a change adds, routes, predicts, or reviews sound.
+
+Audio changes usually cross code, prototypes, localization, and asset licensing. Keep the sound source data-driven, keep immediate player feedback predicted when practical, and keep reusable audio paths out of random call sites.
+
+## Workflow
+
+1. Identify the audio kind.
+- Gameplay feedback: usually a component field, prototype value, or sound collection consumed by an entity system.
+- Ambient, lobby, jukebox, or global music: usually split between server selection and client playback or UI.
+- UI-only sound: keep it client-side unless other players should hear it.
+
+2. Prefer data-driven sound references.
+- Use `SoundSpecifier`, component fields, prototypes, and sound collections for reusable sounds.
+- Avoid hardcoded raw paths in systems when the sound should be configurable by content.
+- Put new audio assets in the narrowest existing `Resources/Audio` subtree and keep fork-only assets under `_OpenSpace` when applicable.
+
+3. Keep prediction and PVS aligned.
+- Use predicted audio APIs for local player actions that should feel immediate.
+- Use PVS-scoped playback for world sounds other nearby players should hear.
+- Do not play the same sound once predicted and once authoritatively unless the existing pattern handles de-duplication.
+
+4. Preserve networking boundaries.
+- Shared code may decide that a sound should happen, but server/client systems should own side-specific playback.
+- Do not introduce client-only audio dependencies into `Content.Shared`.
+
+5. Validate resources.
+- Check paths, sound collection IDs, and prototype references.
+- Confirm attribution or license text for new assets.
+
+## Reference Map
+
+- `../ss14-common-api-patterns/references/audio-popup-random.md`
+- `../ss14-prediction/references/predicted-feedback.md`
+- `../ss14-pvs/SKILL.md`
+- `../ss14-porting-and-licensing/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Shared/**/Audio*.cs`
+- `Content.Server/**/Audio*.cs`
+- `Content.Client/Audio/**`
+- `Resources/Audio/**`
+- `Resources/Prototypes/SoundCollections/**`
+
+## Common Pitfalls
+
+- Hardcoding sound paths in gameplay logic instead of using component data or prototypes.
+- Using server-only `PlayPvs` for a local predicted action that should have immediate feedback.
+- Adding audio assets without attribution or with unclear licensing.
+- Routing music, ambient loops, or UI-only sounds through gameplay systems without a reason.

--- a/.agents/skills/ss14-audio/agents/openai.yaml
+++ b/.agents/skills/ss14-audio/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 Audio"
+  short_description: "Audio, sound collections, and predicted audio feedback"
+  default_prompt: "Use $ss14-audio for SS14 audio, sound prototype, and predicted sound work."

--- a/.agents/skills/ss14-databases-migrations/SKILL.md
+++ b/.agents/skills/ss14-databases-migrations/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ss14-databases-migrations
+description: Work with SS14 server database models, EF Core DbContexts, SQLite/Postgres migrations, persistence services, admin/player data storage, and schema compatibility.
+---
+
+# SS14 Databases And Migrations
+
+Use this skill when a change touches persistent data or database schema.
+
+Database changes are compatibility work. Keep both SQLite and Postgres in sync, avoid runtime-only schema assumptions, and make migrations reviewable.
+
+## Workflow
+
+1. Identify the persistence boundary.
+- `Content.Server.Database` owns database models, contexts, design-time factories, and migrations.
+- Server systems may call persistence services, but gameplay components should not become database transport objects.
+- Shared code should not depend on database projects.
+
+2. Update model and schema together.
+- Add or change EF model fields deliberately.
+- Generate or update migrations for both providers when the schema changes.
+- Keep migration names descriptive and review the generated SQL/model snapshot diff.
+
+3. Preserve data compatibility.
+- Consider existing rows, nullable fields, defaults, indexes, and backfills.
+- Avoid destructive schema changes unless the task explicitly accepts data loss.
+- Keep unique constraints and indexes aligned with query behavior.
+
+4. Keep persistence off hot gameplay paths.
+- Do not add blocking database calls to frequent gameplay events or `Update()`.
+- Batch, cache, or move work to existing async/service patterns when available.
+
+5. Validate both providers when practical.
+- Build database and server projects.
+- Run targeted tests or migration commands if the task changes schema.
+- State clearly when a migration was not exercised locally.
+
+## Reference Map
+
+- `../ss14-client-server-shared/SKILL.md`
+- `../ss14-standard-optimizations/SKILL.md`
+- `../ss14-tests-authoring/SKILL.md`
+- `../ss14-upstream-maintenance/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Server.Database/**`
+- `Content.Shared.Database/**`
+- `Content.Server/**/Database/**`
+- `Content.Server/**/Persistence/**`
+
+## Common Pitfalls
+
+- Updating only SQLite or only Postgres migrations.
+- Using database entities as gameplay state.
+- Adding synchronous database work to gameplay hot paths.
+- Forgetting indexes or uniqueness rules for new lookup patterns.

--- a/.agents/skills/ss14-databases-migrations/agents/openai.yaml
+++ b/.agents/skills/ss14-databases-migrations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 Databases and Migrations"
+  short_description: "Database models, migrations, and persistence"
+  default_prompt: "Use $ss14-databases-migrations for SS14 database, migration, and persistence work."

--- a/.agents/skills/ss14-npc-ai/SKILL.md
+++ b/.agents/skills/ss14-npc-ai/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: ss14-npc-ai
+description: Work with SS14 NPC systems, HTN behavior, pathfinding, steering, AI debug overlays, mindless mobs, hostile or friendly mob behavior, and NPC-related prototypes.
+---
+
+# SS14 NPC And AI
+
+Use this skill when a change affects non-player decision making, pathing, steering, or NPC debug tools.
+
+NPC behavior is server-authoritative gameplay with client debug presentation. Keep AI decisions data-driven where possible and avoid per-tick scans that scale with every mob.
+
+## Workflow
+
+1. Locate the AI layer.
+- Server systems own decisions, targeting, path requests, and authoritative movement intents.
+- Shared code owns shared components, events, and debug/network contracts.
+- Client code owns overlays, EUI/debug windows, and visualization.
+
+2. Prefer data-driven behavior.
+- Use existing HTN, prototype, component, and action patterns before adding special-case code.
+- Keep tunable behavior in prototypes or component fields.
+- Avoid hardcoded entity IDs, faction names, or role assumptions in generic AI systems.
+
+3. Respect pathfinding and steering costs.
+- Avoid broad entity queries, allocations, and expensive path recalculation in frequent updates.
+- Reuse existing steering/pathfinding systems and throttling patterns.
+- Load `ss14-standard-optimizations` for update-heavy AI work.
+
+4. Keep prediction expectations realistic.
+- NPC decisions are server-authoritative.
+- Client visuals/debug overlays should consume replicated or explicit debug state, not run their own gameplay AI.
+
+5. Validate behavior in context.
+- Build affected projects.
+- Prefer an in-game test with multiple NPCs when behavior or performance changes.
+- For debug overlays or EUI, test cleanup when toggled off.
+
+## Reference Map
+
+- `../ss14-standard-optimizations/SKILL.md`
+- `../ss14-transform-physics/SKILL.md`
+- `../ss14-ui-eui/SKILL.md`
+- `../ss14-sprite-overlays-shaders/SKILL.md`
+- `../ss14-netcode/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Shared/NPC/**`
+- `Content.Server/NPC/**`
+- `Content.Client/NPC/**`
+- `Resources/Prototypes/**/NPC/**`
+
+## Common Pitfalls
+
+- Running expensive target/path logic every tick for every NPC.
+- Putting server AI decisions in client debug systems.
+- Hardcoding one mob or faction into a generic AI path.
+- Forgetting to remove debug overlays or network subscriptions when toggles close.

--- a/.agents/skills/ss14-npc-ai/agents/openai.yaml
+++ b/.agents/skills/ss14-npc-ai/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 NPC and AI"
+  short_description: "NPC, HTN, mindless mobs, AI logic, and server authority"
+  default_prompt: "Use $ss14-npc-ai for SS14 NPC, mob AI, HTN, and AI behavior work."

--- a/.agents/skills/ss14-pvs/SKILL.md
+++ b/.agents/skills/ss14-pvs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ss14-pvs
+description: Work with SS14 PVS, visibility, network interest, PVS filters, PVS override behavior, visibility-dependent audio or popups, zoom PVS scale, or systems that behave differently when entities leave PVS.
+---
+
+# SS14 PVS
+
+Use this skill when a change depends on which clients can see, hear, or receive an entity.
+
+PVS is a networking and relevance boundary, not just a visual effect. Keep filters narrow, avoid leaking hidden information, and remember that clients may not know about entities outside their PVS.
+
+## Workflow
+
+1. Decide what must be relevant.
+- World feedback for nearby players should usually use PVS filters or PVS-scoped helpers.
+- Admin, ghost, camera, or debug visibility may require explicit override behavior.
+- UI or client code must tolerate entities leaving PVS or arriving later.
+
+2. Keep network interest narrow.
+- Prefer `Filter.Pvs(...)`, `Filter.PvsExcept(...)`, and existing audio/popup helpers over broadcasting to all players.
+- Do not use global filters for local world feedback unless the feature truly is global.
+- Be cautious with PVS overrides; remove or scope them when the special view ends.
+
+3. Do not assume the client has every entity.
+- Client code should handle missing entities, nullspace, and stale entity references.
+- Avoid client decisions that require hidden server-only or out-of-PVS entities unless a deliberate message/state path provides the data.
+
+4. Coordinate with prediction and feedback.
+- Predicted local feedback may happen before server PVS feedback.
+- Avoid duplicate popups or sounds when both local prediction and PVS broadcasts exist.
+
+5. Validate visibility behavior.
+- Test with another client or call out when multi-client verification was not possible.
+- For admin/debug visibility, check cleanup paths as carefully as setup paths.
+
+## Reference Map
+
+- `../ss14-netcode/SKILL.md`
+- `../ss14-prediction/SKILL.md`
+- `../ss14-audio/SKILL.md`
+- `../ss14-debugging-workflow/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Server/**/Pvs*.cs`
+- `Content.Server/**/PvsOverride*.cs`
+- `Content.Client/**/ContentEye*.cs`
+- `Content.Server/**/Filter*.cs`
+- `Content.Client/**/Overlay*.cs`
+
+## Common Pitfalls
+
+- Broadcasting feedback globally when PVS or station/PVS filters are enough.
+- Assuming a client can resolve an entity that may have left PVS.
+- Leaving PVS overrides active after an admin camera, ghost, or debug view closes.
+- Treating PVS as security for data that should never be sent.

--- a/.agents/skills/ss14-pvs/agents/openai.yaml
+++ b/.agents/skills/ss14-pvs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 PVS"
+  short_description: "PVS, visibility, networking interest, and ghost/debug visibility"
+  default_prompt: "Use $ss14-pvs for SS14 PVS, visibility, and network-interest work."

--- a/.agents/skills/ss14-sprite-overlays-shaders/SKILL.md
+++ b/.agents/skills/ss14-sprite-overlays-shaders/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ss14-sprite-overlays-shaders
+description: Work with SS14 sprites, RSI metadata, sprite layers, overlays, custom visualizers, shaders, lighting-like client effects, and visual assets under `Resources/Textures` or client visual systems.
+---
+
+# SS14 Sprites, Overlays, And Shaders
+
+Use this skill when a change affects visual assets or client-side rendering.
+
+Prefer data-driven sprite and appearance patterns before writing custom rendering code. When custom overlays or shaders are necessary, keep them client-only, narrow, and cheap.
+
+## Workflow
+
+1. Choose the simplest visual path.
+- Prototype sprite layers and `GenericVisualizer` are preferred for normal state-driven visuals.
+- Custom client visualizers are for behavior that prototypes cannot express cleanly.
+- Overlays and shaders are for screen/world rendering effects that are truly rendering concerns.
+
+2. Keep visuals client-owned and state-driven.
+- Gameplay state belongs in shared/server components.
+- Client visuals should read appearance, networked state, or explicit visual events.
+- Do not make rendering systems mutate authoritative gameplay state.
+
+3. Preserve asset conventions.
+- Keep RSI `meta.json` ordering and indentation consistent with repo rules.
+- Put fork-only textures under `_OpenSpace` when applicable.
+- Check license and attribution for new or ported art.
+
+4. Watch render hot paths.
+- Avoid allocations, broad entity scans, and expensive per-frame lookups in overlays.
+- Cache resources and query only the data needed for drawing.
+- Load `ss14-standard-optimizations` for overlays, shaders, or frequently updated visual systems.
+
+5. Validate visuals.
+- Run RSI validation for texture metadata changes.
+- Build client code for overlay/shader changes.
+- Prefer an in-game or screenshot pass when changing visible rendering.
+
+## Reference Map
+
+- `../ss14-graphics-generic-visualizer-appearance/SKILL.md`
+- `../ss14-standard-optimizations/SKILL.md`
+- `../ss14-porting-and-licensing/SKILL.md`
+- `../ss14-prototypes-locale/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Client/**/*Overlay*.cs`
+- `Content.Client/**/*Visualizer*.cs`
+- `Content.Client/**/*Shader*.cs`
+- `Resources/Textures/**`
+- `Resources/Prototypes/**`
+
+## Common Pitfalls
+
+- Writing a custom overlay for a simple sprite-layer toggle.
+- Putting visual-only code in shared or server assemblies.
+- Adding RSI states without validating `meta.json`.
+- Doing heavy entity queries or allocations every frame.

--- a/.agents/skills/ss14-sprite-overlays-shaders/agents/openai.yaml
+++ b/.agents/skills/ss14-sprite-overlays-shaders/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 Sprites, Overlays, and Shaders"
+  short_description: "RSI sprites, overlays, layers, effects, and shaders"
+  default_prompt: "Use $ss14-sprite-overlays-shaders for SS14 sprite, overlay, shader, and visual-layer work."

--- a/.agents/skills/ss14-transform-physics/SKILL.md
+++ b/.agents/skills/ss14-transform-physics/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ss14-transform-physics
+description: Work with SS14 transforms, coordinates, grids, maps, anchoring, containers, movement, collision, fixtures, physics bodies, thrown entities, or spatial queries.
+---
+
+# SS14 Transform And Physics
+
+Use this skill when a change moves entities, changes collision, depends on map/grid coordinates, or edits physics behavior.
+
+Spatial code is fragile because transform, map grids, containers, and physics all interact. Prefer the established entity systems over direct component mutation.
+
+## Workflow
+
+1. Choose the right coordinate space.
+- Use entity coordinates for relative positions and map coordinates for world/map-space decisions.
+- Convert deliberately at system boundaries; do not compare coordinates from different maps or grids without conversion.
+- Handle nullspace, deleted entities, and entities leaving PVS or containers.
+
+2. Use systems for spatial mutations.
+- Prefer `SharedTransformSystem`, `SharedPhysicsSystem`, container systems, and movement systems over direct field writes.
+- Anchoring, parenting, and grid changes should go through the existing APIs so broadphase, fixtures, and dirty state stay coherent.
+- Do not make shared predicted movement depend on server-only systems.
+
+3. Keep collision data data-driven.
+- Prefer prototype fixture and body settings when content should tune collision.
+- If code changes fixture masks, layers, density, or collision state, check the nearby component and prototype patterns.
+
+4. Respect server authority and prediction.
+- Server systems own authoritative physics outcomes.
+- Shared predicted code may provide local responsiveness, but must converge with server state.
+- Avoid random impulses or non-deterministic client-only motion in predicted paths.
+
+5. Validate with focused coverage.
+- Build affected shared/server/client projects.
+- For movement or collision bugs, prefer an in-game pass or a targeted integration test when practical.
+
+## Reference Map
+
+- `../ss14-prediction/SKILL.md`
+- `../ss14-netcode/SKILL.md`
+- `../ss14-standard-optimizations/SKILL.md`
+- `../ss14-ecs-systems/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Shared/**/Movement/**`
+- `Content.Shared/**/Physics/**`
+- `Content.Server/**/Movement/**`
+- `Content.Server/**/Physics/**`
+- `Resources/Prototypes/**`
+
+## Common Pitfalls
+
+- Mutating transform or physics component fields directly.
+- Mixing map and entity coordinates without an explicit conversion.
+- Forgetting containers, anchoring, or grid changes when moving entities.
+- Adding client-only movement that cannot reconcile with server state.

--- a/.agents/skills/ss14-transform-physics/agents/openai.yaml
+++ b/.agents/skills/ss14-transform-physics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 Transform and Physics"
+  short_description: "Coordinates, movement, collision, and physics"
+  default_prompt: "Use $ss14-transform-physics for SS14 transform, coordinate, movement, collision, and physics work."

--- a/.agents/skills/ss14-ui-bui/SKILL.md
+++ b/.agents/skills/ss14-ui-bui/SKILL.md
@@ -1,72 +1,67 @@
 ---
 name: ss14-ui-bui
-description: Implement or review SS14 client UI work. Use when editing `.xaml` or `.xaml.cs` files, bound user interfaces, client windows, style classes, or UI state updates in `Content.Client`, especially when tracing the full shared/server/client chain behind a window, BUI, or predicted interaction.
+description: Work with SS14 Bound User Interfaces, BUI state and messages, UI keys, `BoundUserInterface` client classes, server-side UI handlers, predicted BUI actions, and shared BUI contracts.
 ---
 
-# SS14 UI and BUI
+# SS14 BUI
 
-Use established SS14 and Robust UI patterns instead of inventing new ones.
+Use this skill for entity-bound UI flows. Load `ss14-ui-xaml` as well when editing the paired window layout.
 
-Favor XAML-first layouts, localized text, and predicted-safe client updates. Use the reference files to map the full UI chain before changing code.
+BUIs sit on top of entity state and network messages. Keep the server authoritative, use predicted messages for immediate local actions, and avoid duplicating state that the client already receives through networked components.
 
 ## Workflow
 
-1. Open [ui-flow-map.md](references/ui-flow-map.md) first.
-- Use it to trace shared state, server handlers, client windows, and localization for the feature.
-2. Open [xaml-window-patterns.md](references/xaml-window-patterns.md) for layout conventions.
-3. Open [predicted-bui-patterns.md](references/predicted-bui-patterns.md) when the UI action should feel immediate.
+1. Trace the whole BUI chain before editing.
+- Shared: UI key, state, messages, component state, and predicted contracts.
+- Server: authority, validation, state construction, and message handling.
+- Client: `BoundUserInterface`, window creation, state application, and outgoing messages.
 
-2. Find the full UI chain before editing.
-- Typical paths include a shared component or BUI state in `Content.Shared`, a client BUI/controller in `Content.Client`, paired `.xaml` and `.xaml.cs` files, and sometimes a server-side system that handles messages.
-- Reuse nearby windows and controls in the same feature area before creating a brand-new structure.
+2. Keep state ownership clear.
+- Prefer reading existing networked component state when the client already has it.
+- Add BUI state only for data that is actually UI-specific or not otherwise replicated.
+- Dirty authoritative component state when server actions change replicated data.
 
-3. Prefer XAML-first UI.
-- Use XAML for new windows and controls instead of constructing the entire UI in C#.
-- Keep `.xaml` and `.xaml.cs` paired.
-- Reuse `FancyWindow`, existing style classes, and nearby patterns before editing global stylesheets.
-- If you do add styles, keep them narrowly scoped and consistent with nearby SS14 UI.
+3. Use predicted BUI paths when appropriate.
+- Use predicted messages for local player actions that should feel immediate.
+- Keep predicted shared logic deterministic and safe to replay.
+- Avoid duplicate popups, audio, or visual feedback between prediction and authoritative updates.
 
-4. Keep predicted and networked UI honest.
-- If the client already has the needed data through networked component state, prefer reading that state instead of duplicating it in extra BUI state when the existing pattern supports it.
-- For predicted BUIs, update the UI from component state and `AfterAutoHandleStateEvent` where appropriate.
-- Use `SendPredictedMessage` for predicted UI actions instead of non-predicted message sends.
-- Remember that predicted client code may re-run many times; avoid server-only popup, audio, or UI calls in predicted shared paths.
+4. Validate all incoming requests.
+- Treat client BUI messages as requests.
+- Re-check entity validity, access, distance, permissions, and component state on the server.
+- Handle closed UI, deleted owner, and stale target cases.
 
-5. Localize and stabilize text.
-- Localize window titles, labels, buttons, tooltips, and popups.
-- Use specific FTL keys; do not leave hardcoded player-facing strings in UI code.
-
-6. Validate the change.
-- Build the repo or the relevant projects.
-- Run targeted tests when they exist.
-- If local runtime verification is not possible, say that the UI still needs an in-game pass.
+5. Localize and verify.
+- Localize all window text, buttons, labels, and feedback.
+- Build affected shared/server/client projects.
+- Call out when the UI still needs an in-game pass.
 
 ## Reference Map
 
-- `references/ui-flow-map.md`: full UI chain map, client-only hotspots, and docs caveats for this repo.
-- `references/xaml-window-patterns.md`: XAML-first window rules and pairing reminders.
-- `references/predicted-bui-patterns.md`: predicted messaging and replicated-state reminders for BUIs.
-- `../ss14-client-server-shared/references/shared-and-prediction.md`: shared/client/server ownership for predicted UI flows.
-- `../ss14-localization-code/references/localization-in-code.md`: localized UI text usage in client code.
-- `../ss14-localization-strings/references/ftl-naming-and-layout.md`: FTL key layout for UI text.
+- `references/ui-flow-map.md`
+- `references/predicted-bui-patterns.md`
+- `../ss14-ui-xaml/SKILL.md`
+- `../ss14-prediction/references/bui-prediction.md`
+- `../ss14-netcode/SKILL.md`
+- `../ss14-localization-strings/SKILL.md`
 
 ## Useful References
 
 - `references/ui-flow-map.md`
-- `references/xaml-window-patterns.md`
 - `references/predicted-bui-patterns.md`
+- `references/xaml-window-patterns.md`
 
 ## Good File Anchors
 
-- `Content.Client/**/UI/*.xaml`
-- `Content.Client/**/UI/*.xaml.cs`
 - `Content.Client/**/*BoundUserInterface*.cs`
-- `Content.Shared/**/*Component*.cs`
-- `Content.Shared/**/*System*.cs`
+- `Content.Shared/**/*Bui*.cs`
+- `Content.Shared/**/*Ui*.cs`
+- `Content.Server/**/*System*.cs`
+- `Content.Client/**/*.xaml`
 
 ## Common Pitfalls
 
-- Building a new UI entirely in C# when XAML is the house style.
-- Hardcoding player-facing strings instead of localizing them.
-- Duplicating networked state in separate BUI state without a good reason.
-- Forgetting predicted messaging for interactions that should feel immediate.
+- Trusting client BUI messages without server-side validation.
+- Duplicating networked component state in a separate BUI state without a reason.
+- Sending non-predicted messages for immediate local actions.
+- Forgetting localization for labels, buttons, and feedback.

--- a/.agents/skills/ss14-ui-bui/agents/openai.yaml
+++ b/.agents/skills/ss14-ui-bui/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "SS14 UI and BUI"
-  short_description: "XAML, BUI, and client UI work for SS14"
-  default_prompt: "Use $ss14-ui-bui to implement or review SS14 XAML, BUI, or client UI work."
+  display_name: "SS14 BUI"
+  short_description: "Bound UI state, messages, and prediction"
+  default_prompt: "Use $ss14-ui-bui for SS14 Bound User Interface state, messages, and predicted UI flows."

--- a/.agents/skills/ss14-ui-eui/SKILL.md
+++ b/.agents/skills/ss14-ui-eui/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ss14-ui-eui
+description: Work with SS14 EUI flows, `BaseEui`, `EuiStateBase`, `EuiMessageBase`, admin/debug windows, EUI state serialization, and client/server EUI message handling.
+---
+
+# SS14 EUI
+
+Use this skill for engine-style EUI windows, especially admin and debug tools.
+
+EUI is for explicit client/server UI sessions. Keep messages typed, state minimal, permission-sensitive behavior server-authoritative, and windows tolerant of close/reopen cycles.
+
+## Workflow
+
+1. Map the EUI chain.
+- Client: `BaseEui`, window/control, `HandleState`, and `SendMessage`.
+- Shared: state and message types when both sides need the contract.
+- Server: session setup, permission checks, state construction, and message handling.
+
+2. Keep authority server-side.
+- Validate permissions and target entities on the server for admin/debug actions.
+- Treat client messages as requests, not proof that an action is allowed.
+- Avoid sending sensitive data unless the viewer is authorized.
+
+3. Keep state and messages small.
+- Send IDs, summaries, and requested page data instead of huge object graphs.
+- Use `NetEntity` or stable identifiers for entities crossing the wire.
+- Handle stale targets, disconnects, and windows closing.
+
+4. Pair EUI with XAML carefully.
+- Use `ss14-ui-xaml` for window layout and localized text.
+- Keep EUI message/state logic out of code-behind when a system can own it.
+
+5. Validate with the real role.
+- Admin/debug EUI needs permission-aware runtime testing when possible.
+- Call out when the UI was built but not exercised in-game.
+
+## Reference Map
+
+- `../ss14-ui-xaml/SKILL.md`
+- `../ss14-netcode/SKILL.md`
+- `../ss14-localization-strings/SKILL.md`
+- `../ss14-debugging-workflow/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Client/**/*Eui.cs`
+- `Content.Server/**/*Eui.cs`
+- `Content.Shared/**/*Eui*.cs`
+- `Content.Client/Administration/UI/**`
+
+## Common Pitfalls
+
+- Trusting client EUI messages for admin actions.
+- Sending too much state every update.
+- Forgetting close and stale-entity paths.
+- Mixing BUI and EUI patterns without a reason.

--- a/.agents/skills/ss14-ui-eui/agents/openai.yaml
+++ b/.agents/skills/ss14-ui-eui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 EUI"
+  short_description: "Admin/debug EUI windows and EuiState flows"
+  default_prompt: "Use $ss14-ui-eui for SS14 EUI windows, states, and admin/debug UI flows."

--- a/.agents/skills/ss14-ui-xaml/SKILL.md
+++ b/.agents/skills/ss14-ui-xaml/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ss14-ui-xaml
+description: Work with SS14 XAML windows, controls, `.xaml.cs` code-behind, UI layout, style classes, localized UI text, FancyWindow patterns, and client-side UI widgets.
+---
+
+# SS14 XAML UI
+
+Use this skill for XAML-first client UI layout and code-behind.
+
+XAML should describe layout and stable widgets; code-behind should bind state, events, and formatting without becoming gameplay logic.
+
+## Workflow
+
+1. Find the existing UI family.
+- Reuse nearby `FancyWindow`, control, style, and code-behind patterns.
+- Keep `.xaml` and `.xaml.cs` paired and named consistently.
+- Prefer extending existing controls over creating one-off layouts.
+
+2. Keep layout declarative.
+- Put structure, margins, containers, and named controls in XAML.
+- Keep event wiring, state application, and formatting in code-behind.
+- Do not build an entire window imperatively in C# when XAML is practical.
+
+3. Localize visible text.
+- Use `Loc` bindings or localized code-behind strings for titles, labels, buttons, tooltips, and empty states.
+- Do not commit hardcoded player-facing UI text.
+
+4. Respect UI ownership.
+- XAML and code-behind are client presentation.
+- BUI/EUI state and messages belong in their own skills; load them when the window is backed by networked UI state.
+
+5. Validate the UI path.
+- Build client code after code-behind edits.
+- Run or inspect the UI in-game when practical, especially for dynamic lists and narrow windows.
+
+## Reference Map
+
+- `../ss14-ui-bui/SKILL.md`
+- `../ss14-ui-eui/SKILL.md`
+- `../ss14-localization-strings/SKILL.md`
+- `../ss14-localization-code/SKILL.md`
+
+## Good File Anchors
+
+- `Content.Client/**/*.xaml`
+- `Content.Client/**/*.xaml.cs`
+- `Content.Client/**/UI/**`
+- `Content.Client/**/Styles/**`
+
+## Common Pitfalls
+
+- Constructing full windows in C# instead of XAML.
+- Hardcoding UI text.
+- Adding global style changes for one window.
+- Putting gameplay decisions in code-behind instead of systems or UI message handlers.

--- a/.agents/skills/ss14-ui-xaml/agents/openai.yaml
+++ b/.agents/skills/ss14-ui-xaml/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SS14 XAML UI"
+  short_description: "XAML windows, controls, styles, and localized UI layout"
+  default_prompt: "Use $ss14-ui-xaml for SS14 XAML windows, controls, styles, and UI layout work."

--- a/.agents/skills/ss14-upstream-maintenance/SKILL.md
+++ b/.agents/skills/ss14-upstream-maintenance/SKILL.md
@@ -18,6 +18,7 @@ Use this skill whenever a change touches inherited upstream code or may introduc
 7. Treat `RobustToolbox/` as off-limits unless the task explicitly requires engine work and no content-side path will solve it.
 8. Mirror existing folder paths when adding fork-side extensions.
 9. Prefer reusable extensions and public APIs over one-off branches, special cases, or hardcoded fork behavior.
+10. Mark OpenSpace-specific blocks in files outside `_OpenSpace` with `open-space edit start` / `open-space edit end`.
 
 ## Reference Map
 

--- a/.agents/skills/ss14-upstream-maintenance/references/edit-strategy.md
+++ b/.agents/skills/ss14-upstream-maintenance/references/edit-strategy.md
@@ -12,12 +12,24 @@ Use this file when deciding where and how to implement a change in a fork.
 - Keep diffs narrow inside upstream files.
 - Preserve existing ordering, spacing, and local style in touched files.
 - When creating fork-only behavior, prefer `_OpenSpace` paths that mirror the upstream feature layout.
+- When adding or changing OpenSpace-specific code in a file outside any `_OpenSpace` path, wrap each OpenSpace-specific block with edit markers:
+
+```csharp
+// open-space edit start
+...code here...
+// open-space edit end
+```
+
+- Keep edit-marker ranges as narrow as practical. Do not wrap unrelated upstream code or whole files when only a small block belongs to OpenSpace.
+- Multiple marked blocks in one file are allowed when the OpenSpace changes are separated by upstream code.
+- For files that do not use `//` comments, use the native comment syntax while preserving `open-space edit start` and `open-space edit end`.
 - Prefer reusable hooks, helpers, and data-driven content over one-off special cases or hardcoded values.
 
 ## Good Patterns
 
 - Add fork-specific systems or resources beside the upstream feature in `_OpenSpace`.
 - Extend an existing public system API instead of rewriting the whole feature.
+- Mark narrow OpenSpace-specific edits in inherited files with paired `open-space edit` comments.
 - Add only the fields, prototypes, and locale entries required for the task.
 - Move repeated or feature-configurable behavior into reusable APIs, component data, or prototypes.
 
@@ -25,5 +37,6 @@ Use this file when deciding where and how to implement a change in a fork.
 
 - Moving a large amount of upstream code into fork-only files without need.
 - Refactoring unrelated upstream code while fixing a small gameplay issue.
+- Leaving unmarked OpenSpace-specific code in files outside `_OpenSpace`.
 - Editing engine code because it feels cleaner than respecting content boundaries.
 - Solving one call site with hardcoded IDs, strings, paths, or special-case branches when the code should stay reusable.

--- a/.agents/skills/ss14-upstream-maintenance/references/edit-types.md
+++ b/.agents/skills/ss14-upstream-maintenance/references/edit-types.md
@@ -11,3 +11,13 @@
 ## Rule
 
 Choose the earliest option that fully solves the task without hiding fork behavior in unrelated files, duplicating logic, or hardcoding a one-off case that should stay reusable.
+
+When option 3 requires OpenSpace-specific code in a file outside `_OpenSpace`, keep the patch narrow and wrap each OpenSpace-specific block:
+
+```csharp
+// open-space edit start
+...code here...
+// open-space edit end
+```
+
+Use the file's native comment syntax for non-C# files while preserving the marker text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,15 @@ This repository is a large Space Station 14 fork with a clear split between game
 - Prefer fixing gameplay behavior in content code before assuming an engine change is needed.
 - For fork-only behavior, prefer extending `_OpenSpace` or another clearly fork-scoped area instead of hiding fork logic in unrelated upstream files.
 - When you must touch an upstream content file, keep the diff narrow and preserve surrounding structure and style.
+- When adding or changing OpenSpace-specific code in a file outside any `_OpenSpace` path, wrap each OpenSpace-specific block with edit markers:
+
+```csharp
+// open-space edit start
+...code here...
+// open-space edit end
+```
+
+- Keep edit-marker ranges as narrow as practical. For files that do not use `//` comments, use the native comment syntax while preserving `open-space edit start` and `open-space edit end`.
 
 ## Assembly Placement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ If the task touches `Appearance`, `GenericVisualizer`, visual state enums, or sp
 
 - `ss14-graphics-generic-visualizer-appearance`
 
+If the task touches sprites, RSI metadata, overlays, shaders, or custom client visual effects:
+
+- `ss14-sprite-overlays-shaders`
+
 If the task adds tests or you need to choose the right test layer:
 
 - `ss14-tests-authoring`
@@ -68,6 +72,7 @@ If the task is about bug hunting, VV, logs, breakpoints, or runtime inspection:
 If the task touches common gameplay helpers such as entity-system methods, spawning, prototypes, audio, popups, or random:
 
 - `ss14-common-api-patterns`
+- `ss14-audio` when the work changes audio routing, sound assets, sound collections, or predicted sound feedback
 
 If the task ports code or assets from another repository, or needs license or attribution guidance:
 
@@ -77,9 +82,37 @@ If the task is about how to use AI tools effectively in this repo:
 
 - `ss14-ai-workflow`
 
-If the task edits XAML, BUI flows, client windows, or UI state:
+If the task touches atmospherics, gases, fire, pressure, pipes, atmos devices, or atmos UI:
+
+- `ss14-atmos`
+
+If the task touches transforms, coordinates, grids, maps, anchoring, movement, collision, fixtures, or physics:
+
+- `ss14-transform-physics`
+
+If the task touches PVS, visibility, network interest, PVS filters, PVS overrides, or code that must tolerate entities leaving PVS:
+
+- `ss14-pvs`
+
+If the task edits XAML windows, controls, code-behind, or client UI layout:
+
+- `ss14-ui-xaml`
+
+If the task edits BUI flows, UI keys, BUI state/messages, or `BoundUserInterface` classes:
 
 - `ss14-ui-bui`
+
+If the task edits EUI flows, `BaseEui`, `EuiStateBase`, `EuiMessageBase`, or admin/debug UI sessions:
+
+- `ss14-ui-eui`
+
+If the task touches database models, EF Core contexts, migrations, persistence services, or schema compatibility:
+
+- `ss14-databases-migrations`
+
+If the task touches NPCs, HTN, pathfinding, steering, mob AI, AI debug overlays, or NPC prototypes:
+
+- `ss14-npc-ai`
 
 If a task spans multiple gameplay/resource areas and you need a broad map first:
 

--- a/Content.Client/AGENTS.md
+++ b/Content.Client/AGENTS.md
@@ -7,12 +7,19 @@ For `Content.Client` work always load:
 - `ss14-naming-conventions`
 - `ss14-upstream-maintenance`
 - `ss14-prediction`
-- `ss14-ui-bui`
 
 Also load:
 
+- `ss14-ui-xaml` for XAML windows, controls, code-behind, or client UI layout
+- `ss14-ui-bui` for bound UI classes, BUI state/messages, or predicted BUI flows
+- `ss14-ui-eui` for EUI admin/debug sessions
 - `ss14-localization-strings` and `ss14-localization-code` for UI or popup text
 - `ss14-netcode` when client work depends on replicated messages or `NetEntity`
 - `ss14-graphics-generic-visualizer-appearance` for appearance-driven visual work
+- `ss14-sprite-overlays-shaders` for overlays, shaders, RSI, or visual-layer work
+- `ss14-audio` for client audio, ambient sounds, lobby music, or UI sounds
+- `ss14-atmos` for atmos overlays, pipe visuals, or atmos UI
+- `ss14-pvs` for visibility, PVS scale, or code that handles entities leaving PVS
+- `ss14-transform-physics` for client movement, transform, or physics presentation
 
-Prefer XAML-first UI, client-side presentation, and reading already-networked state before duplicating BUI state.
+Prefer XAML-first UI, client-side presentation, and reading already-networked state before duplicating UI state.

--- a/Content.Server/AGENTS.md
+++ b/Content.Server/AGENTS.md
@@ -16,5 +16,11 @@ Also load:
 - `ss14-prediction` and `ss14-netcode` when the server change commits a shared predicted action or handles network messages
 - `ss14-localization-code` and `ss14-localization-strings` when player-facing text changes
 - `ss14-tests-authoring` when the behavior is risky enough to warrant coverage
+- `ss14-audio` for server-routed world audio, PVS audio, or global sound playback
+- `ss14-atmos` for gas simulation, fire, pipes, atmos devices, or atmos UI authority
+- `ss14-transform-physics` for coordinates, movement, collision, anchoring, or physics
+- `ss14-pvs` for PVS filters, PVS overrides, or network-interest behavior
+- `ss14-databases-migrations` for persistence, EF models, DbContexts, or migrations
+- `ss14-npc-ai` for NPC decisions, HTN, pathfinding, steering, or AI debug data
 
 Keep authority, persistence, and round rules here. If the player should feel the effect immediately, verify the shared prediction path instead of leaving the feature server-only by accident.

--- a/Content.Shared/AGENTS.md
+++ b/Content.Shared/AGENTS.md
@@ -18,5 +18,10 @@ Also load:
 
 - `ss14-localization-code` when shared code emits player text or stores `LocId`
 - `ss14-graphics-generic-visualizer-appearance` when shared gameplay state drives `Appearance` or `GenericVisualizer`
+- `ss14-audio` when shared components or events carry sound specifiers or predicted audio intent
+- `ss14-atmos` when shared components, UI messages, or enums belong to atmos features
+- `ss14-transform-physics` for shared coordinates, movement, collision, anchoring, or physics contracts
+- `ss14-pvs` for PVS-sensitive shared/network contracts
+- `ss14-npc-ai` for shared NPC, HTN, steering, pathfinding, or debug contracts
 
 Shared code owns replicated state, shared events, and prediction-aware logic. Do not add direct client-only or server-only dependencies here.

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -13,5 +13,10 @@ For `Resources` work always load:
 Also load:
 
 - `ss14-graphics-generic-visualizer-appearance` for `Appearance`, `GenericVisualizer`, RSI, or visual layer work
+- `ss14-sprite-overlays-shaders` for RSI metadata, textures, sprite layers, overlays, or shader resources
+- `ss14-audio` for `Resources/Audio`, sound collections, jukebox, lobby, or ambient sound resources
+- `ss14-atmos` for gas, pipe, atmos machine, or fire-related prototypes
+- `ss14-transform-physics` for fixture, body, collision, anchoring, or movement-related prototype data
+- `ss14-npc-ai` for NPC, HTN, faction, steering, or mob AI prototypes
 
 Use the narrowest existing subtree, keep parent prototypes in `base.yml` when you start a new parent tree, and validate YAML or RSI metadata after edits.


### PR DESCRIPTION
<!-- ЭТО НЕ WIZDENОВСКИЙ РЕПОЗИТОРИЙ. ЕСЛИ ВЫ ХОТИТЕ ДОБАВИТЬ ВАШИ ИЗМЕНЕНИЯ НА ВСЕ СЕРВЕРА, СДЕЛАЙТЕ PR НА РЕПОЗИТОРИЙ WIZDEN -->

## Краткое описание

Добавляет вторую часть AI instruction-layer для `open-space`: доменные skills под конкретные подсистемы SS14.

Добавлены новые skills:
- `ss14-audio`
- `ss14-atmos`
- `ss14-transform-physics`
- `ss14-pvs`
- `ss14-ui-xaml`
- `ss14-ui-eui`
- `ss14-sprite-overlays-shaders`
- `ss14-databases-migrations`
- `ss14-npc-ai`

Также:
- `ss14-ui-bui` сужен до BUI-specific guidance;
- XAML, EUI и BUI теперь разделены на отдельные skills;
- обновлен роутинг в `AGENTS.md`;
- обновлен `.agents/rules/ss14-skill-preflight-and-refresh.md`;
- обновлены subtree `AGENTS.md` для `Content.Client`, `Content.Server`, `Content.Shared`, `Resources`.

## Связанные задачи

issue - #38

## Почему мы должны добавить это?

Сейчас AI-агенты и ревью-боты часто смотрят на SS14-код слишком общо: путают client/server/shared границы, забывают про prediction, тащат легаси-паттерны, делают лишние upstream-диффы и не учитывают особенности конкретных подсистем.

Этот PR добавляет более узкую domain-specific guidance для частых сложных зон:
- audio;
- atmos;
- transform / physics;
- PVS;
- XAML / EUI / BUI;
- sprites / overlays / shaders;
- databases / migrations;
- NPC / AI.

Это должно уменьшить количество шумных AI-правок и сделать поведение Codex/других агентов ближе к правилам форка.

Игровую механику PR не меняет.

## Медиа (Видео/Скриншоты)

Не требуется: PR меняет только инструкции для AI-агентов и ревью-ботов.

## Проверочный пункт

- [x] Перед публикацией/запросом на проверку PR, я убедился что изменения работают.
- [x] Я добавил скриншоты/видео изменений, если только этот PR не изменит внутриигровую механику.
- [x] Я подтверждаю, что мои изменения лицензированы в соответствии с лицензией [Open Space Лицензия](https://github.com/ss14-art/open-space/blob/master/LICENSE.TXT) и предоставляю разрешение на их использование в этом репозитории в соответствии с его условиями.

Проверено:
- у новых skills есть `SKILL.md`;
- у новых skills есть `agents/openai.yaml`;
- `name:` в frontmatter совпадает с именем папки;
- TODO в новых skills не осталось;
- `git diff --check` проходит.

**Changelog**

Не требуется: PR не меняет игровой контент или механику.
